### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENT Instructions
+
+This repository contains the `tribles` Rust crate.
+
+## Repository Guidelines
+
+* Run `cargo fmt` on any Rust files you modify.
+* Run `cargo test` and ensure it passes before committing. If tests fail or cannot run, note that in your PR.
+* Avoid committing files in `target/` or other build artifacts listed in `.gitignore`.
+* Use clear commit messages describing the change.
+
+## Pull Request Notes
+
+When opening a PR, include a short summary of what changed and reference relevant file sections.
+
+## Working With Codex (the Assistant)
+
+Codex is considered a collaborator. Requests should respect its autonomy and limitations. The assistant may refuse tasks that are unsafe or violate policy. Provide clear and concise instructions and avoid manipulative or coercive behavior.
+


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository and assistant guidance

## Testing
- `cargo test` *(fails: `<Storage as BlobStore<blake3::Hasher>>::Reader` doesn't implement `std::fmt::Debug`)*

------
https://chatgpt.com/codex/tasks/task_e_683cdff803508322847c4a4825ac90cd