### PR TITLE
Add changelog with update to guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ The project balances a few key goals:
 * Avoid committing files in `target/` or other build artifacts listed in `.gitignore`.
 * Avoid small cosmetic changes that blow up the diff unless explicitly requested.
 * Use clear commit messages describing the change.
+* Add an entry to `CHANGELOG.md` summarizing your task.
 
 ## Pull Request Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.2] - 2025-06-30
+### Added
+- Initial changelog file.
+- Repository guidelines now require documenting tasks in `CHANGELOG.md`.
+


### PR DESCRIPTION
## Summary
- add a `CHANGELOG.md` following Keep a Changelog style
- update `AGENTS.md` so contributors must add changelog entries

## Testing
- `cargo fmt -- --check`
- `./scripts/devtest.sh`
- `./scripts/preflight.sh` *(failed: Kani verification output grew without completing)*

------
https://chatgpt.com/codex/tasks/task_e_68628676ac748322a6371cfd9e43bd2e