### PR TITLE
Add HybridStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository guide.
 - Further clarified `timestamp_distance` documentation that it only works with
   timestamps younger than the ~50-day rollover period.
+- Added `HybridStore` to combine separate blob and branch stores.
 
 ### Changed
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -101,6 +101,7 @@
 pub mod branch;
 pub mod commit;
 //pub mod objectstore;
+pub mod hybridstore;
 pub mod memoryrepo;
 pub mod pile;
 

--- a/src/repo/hybridstore.rs
+++ b/src/repo/hybridstore.rs
@@ -1,0 +1,87 @@
+use crate::blob::{BlobSchema, ToBlob};
+use crate::id::Id;
+use crate::prelude::blobschemas::SimpleArchive;
+use crate::repo::{BlobStore, BlobStorePut, BranchStore, PushResult};
+use crate::value::schemas::hash::{Handle, HashProtocol};
+use crate::value::{Value, ValueSchema};
+
+/// Store that delegates blob and branch operations to two independent stores.
+///
+/// This allows mixing different storage implementations in one repository,
+/// e.g. an on-disk blob store with an in-memory branch store.
+#[derive(Debug)]
+pub struct HybridStore<B, R> {
+    /// Storage for commit, content and metadata blobs.
+    pub blobs: B,
+    /// Storage for branch heads.
+    pub branches: R,
+}
+
+impl<B, R> HybridStore<B, R> {
+    /// Creates a new `HybridStore` from the given blob and branch stores.
+    pub fn new(blobs: B, branches: R) -> Self {
+        Self { blobs, branches }
+    }
+}
+
+impl<H, B, R> BlobStorePut<H> for HybridStore<B, R>
+where
+    H: HashProtocol,
+    B: BlobStorePut<H>,
+{
+    type PutError = B::PutError;
+
+    fn put<S, T>(&mut self, item: T) -> Result<Value<Handle<H, S>>, Self::PutError>
+    where
+        S: BlobSchema + 'static,
+        T: ToBlob<S>,
+        Handle<H, S>: ValueSchema,
+    {
+        self.blobs.put(item)
+    }
+}
+
+impl<H, B, R> BlobStore<H> for HybridStore<B, R>
+where
+    H: HashProtocol,
+    B: BlobStore<H>,
+{
+    type Reader = B::Reader;
+
+    fn reader(&mut self) -> Self::Reader {
+        self.blobs.reader()
+    }
+}
+
+impl<H, B, R> BranchStore<H> for HybridStore<B, R>
+where
+    H: HashProtocol,
+    R: BranchStore<H>,
+{
+    type BranchesError = R::BranchesError;
+    type HeadError = R::HeadError;
+    type UpdateError = R::UpdateError;
+
+    type ListIter<'a>
+        = R::ListIter<'a>
+    where
+        R: 'a,
+        B: 'a;
+
+    fn branches<'a>(&'a self) -> Self::ListIter<'a> {
+        self.branches.branches()
+    }
+
+    fn head(&self, id: Id) -> Result<Option<Value<Handle<H, SimpleArchive>>>, Self::HeadError> {
+        self.branches.head(id)
+    }
+
+    fn update(
+        &mut self,
+        id: Id,
+        old: Option<Value<Handle<H, SimpleArchive>>>,
+        new: Value<Handle<H, SimpleArchive>>,
+    ) -> Result<PushResult<H>, Self::UpdateError> {
+        self.branches.update(id, old, new)
+    }
+}


### PR DESCRIPTION
## Summary
- add `HybridStore` that wraps separate blob and branch stores
- expose new module from `repo`
- document the change in `CHANGELOG.md`

## Testing
- `cargo test`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_686cf3b6f6448322a55ffb3845671969