### PR TITLE
Add mdBook build script and workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,20 @@
+name: Build Book
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: cargo install mdbook
+      - name: Build book
+        run: ./scripts/build_book.sh
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/book

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented `Debug` for `ObjectStoreRemote` and replaced `panic!` calls
   with `.expect()` in object store tests.
 - Initial scaffold for a narrative "Tribles Book" documentation.
+- Build script `build_book.sh` and CI workflow to publish the mdBook.
 
 ### Changed
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.

--- a/book/README.md
+++ b/book/README.md
@@ -5,7 +5,7 @@ This directory contains a work-in-progress guide built with
 locally, run:
 
 ```bash
-mdbook build book
+./scripts/build_book.sh
 ```
 
 The rendered book will appear under `target/book`.

--- a/scripts/build_book.sh
+++ b/scripts/build_book.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Move to repository root
+cd "$(dirname "$0")/.."
+
+# Build the mdBook documentation
+mdbook build book


### PR DESCRIPTION
## Summary
- add `build_book.sh` convenience script
- document using the script in `book/README.md`
- publish the book in new `book.yml` workflow
- note the addition in `CHANGELOG.md`

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873bd4cd7988322a14006d04a77773d