### PR TITLE
Add name conflict handling in branch lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `INVENTORY.md` file and instructions for recording future work.
+- `branch_id_by_name` helper to resolve branch IDs from names. Returns a
+  `NameConflict` error when multiple branches share the same name.
 - Documentation and examples for the repository API.
 - Test coverage for `branch_from` and `checkout_with_key`.
 - Git-based terminology notes in the repository guide and a clearer workspace example.
@@ -51,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delta constraint.
 
 ### Changed
+- Split branch lookup tests into independent cases for better readability.
 - Updated bucket handling to advance RNG state in `bucket_shove_random_slot`.
 - Clarified need for duplicate `bucket_get_slot` check in `table_get_slot`.
 - Replaced Elias--Fano arrays in `SuccinctArchive` with bit vectors for

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -414,6 +414,21 @@ where
     BranchNotFound(Id),
 }
 
+#[derive(Debug)]
+pub enum LookupError<Storage>
+where
+    Storage: BranchStore<Blake3> + BlobStore<Blake3>,
+{
+    StorageBranches(Storage::BranchesError),
+    BranchHead(Storage::HeadError),
+    StorageGet(
+        <<Storage as BlobStore<Blake3>>::Reader as BlobStoreGet<Blake3>>::GetError<UnarchiveError>,
+    ),
+    /// Multiple branches were found with the given name.
+    NameConflict(Vec<Id>),
+    BadBranchMetadata(),
+}
+
 /// High-level wrapper combining a blob store and branch store into a usable
 /// repository API.
 ///
@@ -645,6 +660,47 @@ where
             base_branch_meta: base_branch_meta_handle,
             signing_key,
         })
+    }
+
+    /// Find the id of a branch by its name.
+    pub fn branch_id_by_name(&mut self, name: &str) -> Result<Option<Id>, LookupError<Storage>> {
+        let ids: Vec<Id> = self
+            .storage
+            .branches()
+            .map(|r| r.map_err(|e| LookupError::StorageBranches(e)))
+            .collect::<Result<_, _>>()?;
+
+        let mut handles = Vec::new();
+        for id in ids {
+            if let Some(handle) = self
+                .storage
+                .head(id)
+                .map_err(|e| LookupError::BranchHead(e))?
+            {
+                handles.push((id, handle));
+            }
+        }
+
+        let reader = self.storage.reader();
+        let mut matches = Vec::new();
+        for (id, handle) in handles {
+            let meta: TribleSet = reader.get(handle).map_err(|e| LookupError::StorageGet(e))?;
+
+            let branch_name = find!((n: Value<_>), metadata::pattern!(meta, [{ name: n }]))
+                .exactly_one()
+                .map_err(|_| LookupError::BadBranchMetadata())?
+                .0;
+
+            if branch_name.from_value::<String>() == name {
+                matches.push(id);
+            }
+        }
+
+        match matches.len() {
+            0 => Ok(None),
+            1 => Ok(Some(matches[0])),
+            _ => Err(LookupError::NameConflict(matches)),
+        }
     }
 
     /// Pushes the workspace's new blobs and commit to the persistent repository.

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -1,7 +1,7 @@
 use ed25519_dalek::SigningKey;
 use rand::rngs::OsRng;
 use tribles::prelude::*;
-use tribles::repo::{commit, memoryrepo::MemoryRepo, Repository};
+use tribles::repo::{commit, memoryrepo::MemoryRepo, LookupError, Repository};
 
 #[test]
 fn branch_from_and_checkout_with_key() {
@@ -21,4 +21,35 @@ fn branch_from_and_checkout_with_key() {
     let branch_id = ws.branch_id();
     repo.checkout_with_key(branch_id, other_key)
         .expect("checkout");
+}
+
+#[test]
+fn lookup_branch_id_by_name_found() {
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+    let ws = repo.branch("dev").expect("create branch");
+    let id = ws.branch_id();
+
+    assert_eq!(repo.branch_id_by_name("dev").unwrap(), Some(id));
+}
+
+#[test]
+fn lookup_branch_id_by_name_conflict() {
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+    repo.branch("dev").expect("create branch");
+    repo.branch("dev").expect("create second");
+
+    match repo.branch_id_by_name("dev") {
+        Err(LookupError::NameConflict(ids)) => assert_eq!(ids.len(), 2),
+        _ => panic!("expected NameConflict"),
+    }
+}
+
+#[test]
+fn lookup_branch_id_by_name_missing() {
+    let storage = MemoryRepo::default();
+    let mut repo = Repository::new(storage, SigningKey::generate(&mut OsRng));
+
+    assert_eq!(repo.branch_id_by_name("nothing").unwrap(), None);
 }


### PR DESCRIPTION
## Summary
- return a `NameConflict` error from `branch_id_by_name` when multiple IDs share a name
- update CHANGELOG with new behaviour
- test branch lookup conflict scenario
- split repository branch lookup tests into smaller independent cases
- reuse a single blob reader when searching branch names

## Testing
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_6876e76374688322bcb5249a39473b2d