### PR TITLE
Implement reachable commit collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Workspace::get` method retrieves blobs from the local store and falls back to
   the base store when needed.
 - `OpenError` now implements `std::error::Error` and provides clearer messages when opening piles.
+- Removed the `..=` commit range selector. The `..` selector now follows Git's
+  semantics and excludes the starting commit.
+- Extracted `collect_range` into a standalone function for clarity.
+- Moved `first_parent` into a standalone function for clarity.
+- Added a `collect_reachable` helper to gather all commits reachable from a
+  starting point.
+- Scalar commit selectors once again return only the specified commit.
+- Introduced an `ancestors` selector to retrieve a commit and its history.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/book/src/repository-workflows.md
+++ b/book/src/repository-workflows.md
@@ -29,11 +29,13 @@ repo.push(&mut ws)?;
 ```
 
 You can inspect previous commits using `Workspace::checkout` which returns a
-`TribleSet` with the union of the specified commit contents. Commit ranges
-are supported for convenience:
+`TribleSet` with the union of the specified commit contents. Passing a single
+commit returns just that commit. To include its history you can use the
+`ancestors` helper. Commit ranges are supported for convenience:
 
 ```rust
-let history = ws.checkout(commit_a..=commit_b)?;
+let history = ws.checkout(commit_a..commit_b)?;
+let full = ws.checkout(ancestors(commit_b))?;
 ```
 
 ## Merging and Conflict Handling


### PR DESCRIPTION
## Summary
- add `ancestors` selector to gather a commit's reachable history
- revert scalar selectors to only return the provided commits
- document how to use `ancestors` and mention new selector in changelog
- adjust test to cover new helper

## Testing
- `cargo test --workspace`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e4ddd5310832284d105d2de14c579