### PR TITLE
Rename delta! macro to pattern_changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pattern!` now reuses attribute variables for identical field names.
 - Clarified that the project's developer experience goal also includes
   providing an intuitive API for library users.
+- Renamed the `delta!` macro to `pattern_changes!` and changed its
+  signature to `(current, changes, [pattern])` assuming the caller
+  computes the delta set.
 - Documented Kani proof guidelines to avoid constants and prefer
   `kani::any()` or bounded constructors for nondeterministic inputs.
 - Fixed Kani playback build errors by using `dst_len` to access `child_table`

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -4,8 +4,8 @@
 - None at the moment.
 
 ## Completed Work
-- Implemented a `delta!` macro for incremental queries. The macro
-  computes the difference between two `TribleSet`s and unions per-triple
+- Implemented a `pattern_changes!` macro for incremental queries. The macro
+  takes the current dataset and a precomputed changeset, unioning per-triple
   results so callers only see newly inserted data.
 
 ## Desired Functionality

--- a/book/src/incremental-queries.md
+++ b/book/src/incremental-queries.md
@@ -12,10 +12,10 @@ case yields the new solutions introduced by those additions and we then
 union all of the per‑constraint results.
 
 To help express these delta queries at the macro level, namespaces now
-offer a `delta!` operator. It behaves like `pattern!` but takes the
-previous and current `TribleSet`. The macro computes their difference
-and then calls `union!` internally to apply the resulting delta
-constraint, matching only the newly inserted tribles. Combined with the
+offer a `pattern_changes!` operator. It behaves like `pattern!` but takes the
+current `TribleSet` and a precomputed changeset. The macro simply unions
+variants of the query where each triple is constrained to that changeset,
+matching only the newly inserted tribles. Combined with the
 union constraint, this lets us run incremental updates using the familiar
 `find!` interface.
 

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -76,10 +76,10 @@ macro_rules! NS {
             }
 
             #[macro_pub::macro_pub]
-            macro_rules! delta {
-                ($prev:expr, $curr:expr, $pattern: tt) => {
+            macro_rules! pattern_changes {
+                ($curr:expr, $changes:expr, $pattern: tt) => {
                     {
-                        ::tribles_macros::delta!{ ::tribles, $mod_name, $prev, $curr, $pattern }
+                        ::tribles_macros::pattern_changes!{ ::tribles, $mod_name, $curr, $changes, $pattern }
                     }
                 };
             }
@@ -236,9 +236,10 @@ mod tests {
             quote: "To be, or not to be, that is the question.".to_blob().get_handle()
         });
 
+        let delta = &updated.difference(&base);
         let r: Vec<_> = find!(
             (author, hamlet, title),
-            literature::delta!(&base, &updated, [
+            literature::pattern_changes!(&updated, delta, [
             {author @
              firstname: ("William"),
              lastname: ("Shakespeare")},


### PR DESCRIPTION
## Summary
- rename the macro and parser to `pattern_changes!`
- update invocation sites and docs for the new name
- note the rename in the changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688117ffcb748322a26a1eb94f4f6efb