### PR TITLE
Design notes for garbage collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation proposal for exposing blob metadata through the `Pile` API.
 - `IndexEntry` now stores a timestamp for each blob. `PileReader::metadata`
   returns this timestamp along with the blob length.
+- Design notes for a conservative garbage collection mechanism that scans
+  `SimpleArchive` values in place to find reachable handles.
+- Clarified that accidental collisions are practically impossible given 32-byte
+  hashes, explaining why the collector can treat any matching value as a real
+  reference.
 - Repository workflows chapter covering branching, merging, CLI usage and an improved push/merge diagram.
 - Separate `verify.sh` script for running Kani verification.
 - Documented conflict resolution loop and clarified that returned workspaces

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -19,6 +19,9 @@
 - Benchmark PATCH performance across typical workloads.
 - Investigate the theoretical complexity of PATCH operations.
 - Measure practical space usage for PATCH with varying dataset sizes.
+- Implement a garbage collection mechanism that scans branch and commit
+  archives without fully deserialising them to find reachable blob handles.
+  Anything not discovered this way can be forgotten by the underlying store.
 
 ## Documentation
 - Move the "Portability & Common Formats" overview from `src/value.rs` into a

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Schemas](schemas.md)
 - [Repository Workflows](repository-workflows.md)
 - [Commit Selectors](commit-selectors.md)
+- [Garbage Collection](garbage-collection.md)
 - [Deep Dive](deep-dive/README.md)
   - [Philosophy](deep-dive/philosophy.md)
   - [Identifiers](deep-dive/identifiers.md)

--- a/book/src/garbage-collection.md
+++ b/book/src/garbage-collection.md
@@ -1,0 +1,48 @@
+# Garbage Collection and Forgetting
+
+Repositories grow over time as new blobs are written for commits, branch
+metadata and user data.  Because each blob is content addressed there is no
+built‑in mechanism to reclaim space when branches move or objects become
+orphaned.  A repository may choose to _forget_ unreachable blobs to recover
+storage.  Forgetting does not violate TribleSpace's monotonic model – removed
+blobs can always be reintroduced if discovered again – but it requires a
+conservative reachability analysis to avoid discarding data still referenced by
+existing branches.
+
+## Conservative Reachability
+
+Every commit and branch metadata record is stored as a `SimpleArchive`.  The
+format is a canonicalised `TribleSet` encoded as alternating 32‑byte keys and
+values.  When searching for references we do not rebuild the set.  Instead we
+scan the archive in 32‑byte chunks and treat every second segment as a candidate
+value.  Any segment that matches the hash of a blob in the store is considered a
+potential handle.  The type of the attribute is irrelevant; if the bytes happen
+to equal a known handle we assume a reference exists.  With 32‑byte hashes the
+chance of a random collision is vanishingly small, so a match strongly implies a
+real reference.  This heuristic may keep more blobs than strictly necessary but
+never frees ones that are still in use.
+
+## Traversal Algorithm
+
+1. Enumerate all branches and load their metadata blobs.
+2. For each metadata blob extract values that look like blob handles.  This
+   yields the current commit head as well as any other referenced blobs.
+3. Recursively walk commit and content blobs discovered this way.  Whenever a
+   referenced blob is a `SimpleArchive`, scan every second 32‑byte segment for
+   handles instead of deserialising the entire set.
+4. Collect every handle visited during the walk into a `TribleSet`.  Repositories
+   that implement a `keep`‑style operation can feed this set back to the blob
+   store to drop everything else.
+
+Content blobs that are not `SimpleArchive` instances (for example large binary
+attachments) are treated as leaves.  They become reachable when some archive
+contains their handle and are otherwise eligible for forgetting.
+
+## Future Work
+
+The exact API for triggering garbage collection is still open.  One option is a
+`Repository::forget_unreachable()` helper that relies on the blob store to
+implement a pruning method.  Another approach could expose a generic
+`ReachabilityWalker` so applications can decide how to handle or export reachable
+blobs.  Regardless of the final interface, conservative reachability based on
+scanning `SimpleArchive` bytes lays the groundwork for safe space reclamation.


### PR DESCRIPTION
## Summary
- document a plan for garbage collection/forgetting blobs
- add the new design chapter to the book
- record follow-up work in the inventory
- note the design in the changelog
- clarify that `SimpleArchive` blobs can be scanned without full deserialization
- mention that collisions are virtually impossible with 32-byte hashes

## Testing
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688138e823888322ae22d6c9775282fc