### PR TITLE
Fix ByteTable benchmark load factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded the repository example to store actual data and simplified the conflict loop.
 - Failing test `ns_local_ids_bad_estimates_panics` shows mis-ordered variables return no results when a panic is expected.
 ### Fixed
+- ByteTable resize benchmark now reports load factor for fully populated 256-slot tables.
 - `PatchIdConstraint` incorrectly used 32-byte values when confirming IDs, causing
   `local_ids` queries to return no results with overridden estimates.
 - Documentation proposal for exposing blob metadata through the `Pile` API.

--- a/benches/patch.rs
+++ b/benches/patch.rs
@@ -81,6 +81,10 @@ fn byte_table_resize_benchmark() {
                     }
                 }
             }
+
+            // Record the fill after the final insertions without a subsequent resize.
+            let index = usize::ilog2(size) as usize - 1;
+            inserted_totals[index] += inserted;
         }
 
         let mut by_size = Vec::new();

--- a/book/src/deep-dive/patch.md
+++ b/book/src/deep-dive/patch.md
@@ -26,33 +26,33 @@ before triggering a resize. The benchmark inserts all byte values many times
 and measures the occupancy that forced each power-of-two table size to grow:
 
 ```
-ByteTable resize fill - random: 0.744, sequential: 0.840
+ByteTable resize fill - random: 0.863, sequential: 0.972
 Per-size fill (random)
   size   2: 1.000  # path compression keeps two-entry nodes fully occupied
-  size   4: 0.975
-  size   8: 0.897
-  size  16: 0.841
-  size  32: 0.789
-  size  64: 0.734
-  size 128: 0.713
-  size 256: 0.000  # identity hash maps all 256 children so no resize occurs
+  size   4: 0.973
+  size   8: 0.899
+  size  16: 0.830
+  size  32: 0.749
+  size  64: 0.735
+  size 128: 0.719
+  size 256: 1.000  # identity hash maps all 256 children without resizing
 Per-size fill (sequential)
   size   2: 1.000  # path compression keeps two-entry nodes fully occupied
   size   4: 1.000
-  size   8: 0.936
-  size  16: 0.990
-  size  32: 0.921
-  size  64: 0.944
-  size 128: 0.926
-  size 256: 0.000  # identity hash maps all 256 children so no resize occurs
+  size   8: 0.993
+  size  16: 1.000
+  size  32: 0.928
+  size  64: 0.925
+  size 128: 0.927
+  size 256: 1.000  # identity hash maps all 256 children without resizing
 ```
 
-Random inserts average roughly 74% table fill while sequential inserts hold
-about 84% before doubling the table size. Nodes of size two are always 100%
+Random inserts average roughly 86% table fill while sequential inserts hold
+about 97% before doubling the table size. Nodes of size two are always 100%
 full thanks to path compression, and the final 256‑ary node also reaches 100%
-occupancy because of the linear hash. The benchmark shows `0.000` for the 256
-size as it never triggers a resize. This keeps memory usage predictable without
-the specialized node formats used by ART.
+occupancy because of the linear hash, which we now report explicitly instead of
+`0.000`. This keeps memory usage predictable without the specialized node
+formats used by ART.
 
 PATCH nodes maintain a rolling hash which allows efficient union, intersection and difference operations over whole subtrees.
 Keys can be viewed in different orders with the [`KeyOrdering`](../../src/patch.rs) trait and segmented via [`KeySegmentation`](../../src/patch.rs) to enable prefix based queries.


### PR DESCRIPTION
## Summary
- record final ByteTable occupancy so resize benchmark reports 256-slot load factor
- refresh patch deep dive with updated benchmark results
- note the benchmark fix in the changelog

## Testing
- `cargo bench --bench patch`
- `mdbook build book`
- `cargo test`
- `./scripts/preflight.sh`


------
https://chatgpt.com/codex/tasks/task_e_688bd6bd7c848322a68b0a173277c381