### PR TITLE
Inline u128 bitset in ByteSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced redundant option check with an `expect` when traversing full buckets in
   the ByteTable planner.
 - Restored the simpler `ByteSet` and inlined bucket checks to reduce indirection in the planner.
+- `ByteSet` now stores raw `[u128; 2]` bitsets instead of relying on `VariableSet`.
 ### Fixed
 - ByteTable resize benchmark now reports load factor for fully populated 256-slot tables.
 - `PatchIdConstraint` incorrectly used 32-byte values when confirming IDs, causing

--- a/src/patch/bytetable.rs
+++ b/src/patch/bytetable.rs
@@ -35,7 +35,6 @@
 //! current bucket, to the corresponding bucket in the upper half.
 //! Incidentally this might flip the hash function used for this entry.
 
-use crate::query::VariableSet;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use std::fmt::Debug;
@@ -161,26 +160,26 @@ fn compress_hash(slot_count: usize, hash: u8) -> u8 {
 }
 
 #[derive(Clone, Copy)]
-struct ByteSet([VariableSet; 2]);
+struct ByteSet([u128; 2]);
 
 impl ByteSet {
     fn new_empty() -> Self {
-        ByteSet([VariableSet::new_empty(), VariableSet::new_empty()])
+        ByteSet([0, 0])
     }
 
     fn insert(&mut self, idx: u8) {
-        let bit = (idx & 0b0111_1111) as usize;
-        self.0[(idx >> 7) as usize].set(bit);
+        let bit = (idx & 0b0111_1111) as u32;
+        self.0[(idx >> 7) as usize] |= 1u128 << bit;
     }
 
     fn remove(&mut self, idx: u8) {
-        let bit = (idx & 0b0111_1111) as usize;
-        self.0[(idx >> 7) as usize].unset(bit);
+        let bit = (idx & 0b0111_1111) as u32;
+        self.0[(idx >> 7) as usize] &= !(1u128 << bit);
     }
 
     fn contains(&self, idx: u8) -> bool {
-        let bit = (idx & 0b0111_1111) as usize;
-        self.0[(idx >> 7) as usize].is_set(bit)
+        let bit = (idx & 0b0111_1111) as u32;
+        (self.0[(idx >> 7) as usize] & (1u128 << bit)) != 0
     }
 }
 


### PR DESCRIPTION
## Summary
- store ByteSet data as `[u128; 2]` instead of `VariableSet`
- document change in changelog

## Testing
- `cargo test`
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d26d2ed548322a58cccf2814597a0