### PR TITLE
Add regression test for ordered patch iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ThompsonEngine` implementing a new `PathEngine` trait for regular path queries,
   and `RegularPathConstraint` is now generic over `PathEngine`.
 - Implemented `size_hint`, `ExactSizeIterator`, and `FusedIterator` for `PATCHIterator` and `PATCHOrderedIterator`.
+- Regression test ensures `PATCH::iter_ordered` yields canonically ordered keys.
 - Debug helpers `EstimateOverrideConstraint` and `DebugConstraint` moved to a new
   `debug` module.
 - Debug-only `debug_branch_fill` method computes average PATCH branch fill

--- a/tests/patch_ordered_iterator.rs
+++ b/tests/patch_ordered_iterator.rs
@@ -1,0 +1,22 @@
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use std::collections::HashSet;
+use tribles::patch::{Entry, PATCH};
+use tribles::trible::EAVOrder;
+
+#[test]
+fn iter_ordered_returns_sorted_keys() {
+    let mut patch: PATCH<64, EAVOrder> = PATCH::new();
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut keys = HashSet::new();
+    while keys.len() < 1000 {
+        let mut key = [0u8; 64];
+        rng.fill_bytes(&mut key);
+        if keys.insert(key) {
+            patch.insert(&Entry::new(&key));
+        }
+    }
+    let mut sorted_keys: Vec<[u8; 64]> = keys.iter().cloned().collect();
+    sorted_keys.sort();
+    let collected: Vec<[u8; 64]> = patch.iter_ordered().cloned().collect();
+    assert_eq!(collected, sorted_keys);
+}


### PR DESCRIPTION
## Summary
- add regression test verifying `PATCH::iter_ordered` yields keys in canonical order
- document test in changelog

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a211b8ff288322803b39747a4c2901