### PR TITLE
Restore atomic pile writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `nth_parent` commit selector and helper; parent-numbering is not planned.
 - Unused `crossbeam-channel` dependency.
 ### Fixed
+- Restored atomic vectored blob appends and single-call branch writes; errors
+  if any bytes are missing.
 - Removed duplicate `succinct-archive` feature declarations that prevented
   builds.
 - Corrected blob offsets in `Pile` so retrieved blobs no longer include headers or


### PR DESCRIPTION
## Summary
- ensure blob appends use a single `write_vectored` and error on partial writes
- document restoration of atomic pile writes

## Testing
- `cargo test`
- `cargo fmt -- --check`


------
https://chatgpt.com/codex/tasks/task_e_68aa385143b88322a569f26966914418