### PR TITLE
Unlock file on refresh error in pile updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,6 +377,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Enforce `PREFIX_LEN <= KEY_LEN` for prefix checks in PATCH.
+- Release file locks if `refresh` fails during pile branch updates to avoid lingering locks.
 
 ## [0.5.2] - 2025-06-30
 ### Added


### PR DESCRIPTION
## Summary
- unlock pile file if `refresh` errors during branch update
- rename duplicate pile tests and remove duplicate import
- note change in changelog

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aaf04c2b6c832282069c1748097b0e