### PR TITLE
Ensure branch map updates only after durable writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -399,6 +399,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforce `PREFIX_LEN <= KEY_LEN` for prefix checks in PATCH.
 - Release file locks if `refresh` fails during pile branch updates to avoid lingering locks.
 - Blob insertion now returns an error instead of panicking if the system clock goes backwards.
+- Delay branch map updates until after branch records are written to disk, preventing divergence when writes fail.
 
 ## [0.5.2] - 2025-06-30
 ### Added

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -753,8 +753,6 @@ where
 
             let header_len = std::mem::size_of::<BranchHeader>();
 
-            self.branches.insert(id, new);
-
             let header = BranchHeader::new(id, new);
             let expected = header_len;
             let written = match self.file.write(header.as_bytes()) {
@@ -782,6 +780,7 @@ where
                 self.file.unlock()?;
                 return Err(UpdateBranchError::IoError(e));
             }
+            self.branches.insert(id, new);
             self.file.unlock()?;
             Ok(PushResult::Success())
         };


### PR DESCRIPTION
## Summary
- avoid branch map divergence by inserting updates after branch records sync to disk
- document branch map update ordering fix

## Testing
- `./scripts/preflight.sh`
- `cargo test --lib`


------
https://chatgpt.com/codex/tasks/task_e_68ad7a16251083229893bf77a0785e05