### PR TITLE
Handle oversized pile mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `IndexEntry::Stored` tracks offsets and lengths instead of holding `Bytes` directly.
 - Regression test ensures `PATCH::iter_ordered` yields canonically ordered keys.
 - `PATCH::replace` method replaces existing keys without removing/ reinserting.
+
+### Fixed
+- Opening excessively large piles now returns an error instead of panicking when calculating the mapped size.
 - Regression tests verify blob bytes remain intact after branch updates and across flushes.
 - `PileReader::metadata` now validates blob contents and returns `None` for corrupted blobs.
 - `PileBlobStoreIter` now lazily verifies blob hashes and reports errors for invalid blobs.

--- a/src/repo/pile.rs
+++ b/src/repo/pile.rs
@@ -290,6 +290,7 @@ impl<H: HashProtocol> BlobStore<H> for Pile<H> {
 pub enum ReadError {
     IoError(std::io::Error),
     CorruptPile { valid_length: usize },
+    FileTooLarge { length: usize },
 }
 
 impl std::fmt::Display for ReadError {
@@ -298,6 +299,9 @@ impl std::fmt::Display for ReadError {
             ReadError::IoError(err) => write!(f, "IO error: {err}"),
             ReadError::CorruptPile { valid_length } => {
                 write!(f, "Corrupt pile at byte {valid_length}")
+            }
+            ReadError::FileTooLarge { length } => {
+                write!(f, "Pile of length {length} exceeds supported size")
             }
         }
     }
@@ -317,6 +321,10 @@ impl From<ReadError> for std::io::Error {
             ReadError::CorruptPile { valid_length } => std::io::Error::new(
                 std::io::ErrorKind::Other,
                 format!("corrupt pile at byte {valid_length}"),
+            ),
+            ReadError::FileTooLarge { length } => std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("pile length {length} exceeds supported size"),
             ),
         }
     }
@@ -438,7 +446,11 @@ impl<H: HashProtocol> Pile<H> {
         let length = file.metadata()?.len() as usize;
         let page_size = page_size::get();
         let base_size = page_size * 1024;
-        let mapped_size = base_size.max(length.next_power_of_two());
+        let mapped_size = base_size.max(
+            length
+                .checked_next_power_of_two()
+                .ok_or(ReadError::FileTooLarge { length })?,
+        );
 
         let mmap = MmapOptions::new()
             .len(mapped_size)

--- a/tests/pile_too_large.rs
+++ b/tests/pile_too_large.rs
@@ -1,0 +1,21 @@
+use tribles::prelude::*;
+use tribles::repo::pile::ReadError;
+use tribles::value::schemas::hash::Blake3;
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn open_near_usize_max_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pile.pile");
+    let file = std::fs::File::create(&path).unwrap();
+    let large = (usize::MAX as u64 / 2) + 1;
+    if file.set_len(large).is_err() {
+        return;
+    }
+    drop(file);
+    match Pile::<Blake3>::open(&path) {
+        Err(ReadError::FileTooLarge { .. }) => {}
+        Err(e) => panic!("unexpected error: {e:?}"),
+        Ok(_) => panic!("expected error opening overly large pile"),
+    }
+}


### PR DESCRIPTION
## Summary
- avoid next_power_of_two overflow by checking pile length and returning a `FileTooLarge` error
- add regression test opening near-`usize::MAX` piles

## Testing
- `./scripts/preflight.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b0b93e145c8322b77bbc005d2fcf58