### PR TITLE
Fix blob book example repo import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PATCH::replace` method replaces existing keys without removing/ reinserting.
 
 ### Fixed
+- Corrected the blob book example to import the repository module via `tribles::repo`.
 - Removed an unused `anyhow` import from the succinct archive schema.
 - `SuccinctArchive::from` now handles empty `TribleSet`s and returns an
   empty archive instead of panicking.

--- a/book/src/deep-dive/blobs.md
+++ b/book/src/deep-dive/blobs.md
@@ -11,7 +11,7 @@ The following example demonstrates creating blobs, archiving a `TribleSet` and s
 ```rust
 use tribles::prelude::*;
 use tribles::examples::literature;
-use tribles::repo::repo;
+use tribles::repo;
 use valueschemas::{Handle, Blake3};
 use blobschemas::{SimpleArchive, LongString};
 use rand::rngs::OsRng;


### PR DESCRIPTION
## Summary
- update the Blobs chapter example to import the repository module from `tribles::repo`
- note the documentation fix in the changelog

## Testing
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68ced440f71c8322ba7e5a01db926a2c