### PR TITLE
Add scoped `_?` pattern locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test coverage for `branch_from` and `pull_with_key`.
 - Migrated `SuccinctArchive` to new `jerky`/`anybytes` APIs and added
   serializable metadata.
+- `_?name` scoped variables for `pattern!`/`pattern_changes!` along with
+  documentation and tests demonstrating their use.
 - Implemented `ToBlob`/`TryFromBlob` for `SuccinctArchive`, enabling archive
   serialization as a blob.
 - `Pile::restore` method to repair piles with trailing corruption.

--- a/README.md
+++ b/README.md
@@ -134,11 +134,26 @@ fn main() -> std::io::Result<()> {
         let q: View<str> = blobs.reader().unwrap().get(q).unwrap();
         let q = q.as_ref();
 
-        println!("'{q}'\n - from {title} by {f} {}.", l.from_value::<&str>())
-    }
-    Ok(())
+println!("'{q}'\n - from {title} by {f} {}.", l.from_value::<&str>())
+}
+Ok(())
 }
 ```
+
+You can also introduce temporary equality constraints inside a pattern without
+adding them to the surrounding `find!` bindings. Prefix a variable name with
+`_?` to allocate a scoped query variable that lives only for the duration of the
+macro expansion:
+
+```ignore
+pattern!(&set, [{
+    ?author @ literature::firstname: _?name,
+    literature::lastname: _?name,
+}]);
+```
+
+This binds both attributes to the same generated variable, ensuring the first
+and last names match without cluttering the outer query signature.
 
 ## Tribles Book
 

--- a/book/src/deep-dive/identifiers.md
+++ b/book/src/deep-dive/identifiers.md
@@ -204,6 +204,13 @@ for (author, name) in find!(
 }
 ```
 
+Sometimes you want to compare two attributes without exposing the comparison
+variable outside the pattern. Prefixing the binding with `_?`, such as
+`_?name`, allocates a scoped variable local to the macro invocation. Both
+`pattern!` and `pattern_changes!` will reuse the same generated query variable
+whenever the `_?` form appears again, letting you express equality constraints
+inline without touching the outer [`find!`](crate::query::find) signature.
+
 Binding the variable as an [`ExclusiveId`](crate::id::ExclusiveId) means the
 closure that [`find!`](crate::query::find) installs will run the
 [`FromValue`](crate::value::FromValue) implementation for `ExclusiveId`.

--- a/tests/pattern_local_vars.rs
+++ b/tests/pattern_local_vars.rs
@@ -1,0 +1,60 @@
+use crate::{entity, pattern, pattern_changes};
+use tribles::prelude::*;
+use trybuild::TestCases;
+
+pub mod names {
+    use tribles::prelude::*;
+
+    attributes! {
+        "D02189E4C5A74E84B0FCBFDE3C533A0B" as first: valueschemas::ShortString;
+        "8F2E5E6A6D9C42F2A4BF6471C5FBF5E0" as last: valueschemas::ShortString;
+    }
+}
+
+#[test]
+fn pattern_local_variables_compile() {
+    let t = TestCases::new();
+    t.pass("tests/trybuild/pattern_local_variables.rs");
+}
+
+#[test]
+fn pattern_local_variables_enforce_equality() {
+    let mut kb = TribleSet::new();
+
+    let same = ufoid();
+    kb += entity! { &same @ names::first: "Same", names::last: "Same" };
+
+    let different = ufoid();
+    kb += entity! { &different @ names::first: "Alice", names::last: "Smith" };
+
+    let results: Vec<_> = find!(
+        (person: Value<_>),
+        pattern!(&kb, [
+            { ?person @ names::first: _?name, names::last: _?name }
+        ])
+    )
+    .collect();
+
+    assert_eq!(results, vec![(same.to_value(),)]);
+}
+
+#[test]
+fn pattern_changes_local_variables_track_deltas() {
+    let base = TribleSet::new();
+    let mut updated = base.clone();
+
+    let same = ufoid();
+    updated += entity! { &same @ names::first: "Same", names::last: "Same" };
+
+    let delta = updated.difference(&base);
+
+    let results: Vec<_> = find!(
+        (person: Value<_>),
+        pattern_changes!(&updated, &delta, [
+            { ?person @ names::first: _?name, names::last: _?name }
+        ])
+    )
+    .collect();
+
+    assert_eq!(results, vec![(same.to_value(),)]);
+}

--- a/tests/trybuild/pattern_local_variables.rs
+++ b/tests/trybuild/pattern_local_variables.rs
@@ -1,0 +1,36 @@
+use tribles::prelude::*;
+
+mod names {
+    use tribles::prelude::*;
+
+    attributes! {
+        "D02189E4C5A74E84B0FCBFDE3C533A0B" as first: valueschemas::ShortString;
+        "8F2E5E6A6D9C42F2A4BF6471C5FBF5E0" as last: valueschemas::ShortString;
+    }
+}
+
+fn main() {
+    let base = TribleSet::new();
+    let mut kb = base.clone();
+
+    let same = ufoid();
+    kb += entity! { &same @ names::first: "Same", names::last: "Same" };
+
+    let delta = kb.difference(&base);
+
+    let _: Vec<_> = find!(
+        (person: Value<_>),
+        pattern!(&kb, [
+            { ?person @ names::first: _?name, names::last: _?name }
+        ])
+    )
+    .collect();
+
+    let _: Vec<_> = find!(
+        (person: Value<_>),
+        pattern_changes!(&kb, &delta, [
+            { ?person @ names::first: _?name, names::last: _?name }
+        ])
+    )
+    .collect();
+}

--- a/tribles-macros/src/lib.rs
+++ b/tribles-macros/src/lib.rs
@@ -319,6 +319,8 @@ struct Entity {
 enum Value {
     /// `?ident` — bind this identifier as a query variable
     Var(Ident),
+    /// `_?ident` — allocate a scoped variable local to the macro invocation
+    LocalVar(Ident),
     /// Arbitrary Rust expression used as a literal value
     Expr(Expr),
 }
@@ -384,6 +386,16 @@ impl Parse for Attribute {
 
 impl Parse for Value {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        if input.peek(Token![_]) {
+            let fork = input.fork();
+            fork.parse::<Token![_]>()?;
+            if fork.peek(Token![?]) {
+                input.parse::<Token![_]>()?;
+                input.parse::<Token![?]>()?;
+                let var_ident: Ident = input.parse()?;
+                return Ok(Value::LocalVar(var_ident));
+            }
+        }
         if input.peek(Token![?]) {
             input.parse::<Token![?]>()?;
             let var_ident: Ident = input.parse()?;
@@ -446,6 +458,9 @@ fn pattern_impl(input: TokenStream) -> syn::Result<TokenStream> {
     let mut val_idx = 0usize;
     use std::collections::HashMap;
     let mut attr_map: HashMap<String, (Ident, Ident)> = HashMap::new();
+    let mut local_tokens = TokenStream2::new();
+    let mut local_map: HashMap<String, Ident> = HashMap::new();
+    let mut local_idx = 0usize;
 
     // Expand one block per entity described in the pattern.
     for (entity_idx, entity) in pattern.into_iter().enumerate() {
@@ -458,6 +473,22 @@ fn pattern_impl(input: TokenStream) -> syn::Result<TokenStream> {
             match id_val {
                 Value::Var(ref ident) => {
                     quote! { let #e_ident = #ident; }
+                }
+                Value::LocalVar(ref ident) => {
+                    let key = format!("_?{}", ident);
+                    let local_ident = if let Some(existing) = local_map.get(&key) {
+                        existing.clone()
+                    } else {
+                        let new_ident =
+                            format_ident!("__local{}", local_idx, span = Span::mixed_site());
+                        local_idx += 1;
+                        local_tokens.extend(quote! {
+                            let #new_ident = #ctx_ident.next_variable();
+                        });
+                        local_map.insert(key, new_ident.clone());
+                        new_ident
+                    };
+                    quote! { let #e_ident = #local_ident; }
                 }
                 Value::Expr(ref id_expr) => {
                     quote! {
@@ -516,6 +547,28 @@ fn pattern_impl(input: TokenStream) -> syn::Result<TokenStream> {
                         }
                     }
                 }
+                Value::LocalVar(ref local_ident) => {
+                    let key = format!("_?{}", local_ident);
+                    let stored_ident = if let Some(existing) = local_map.get(&key) {
+                        existing.clone()
+                    } else {
+                        let new_ident =
+                            format_ident!("__local{}", local_idx, span = Span::mixed_site());
+                        local_idx += 1;
+                        local_tokens.extend(quote! {
+                            let #new_ident = #ctx_ident.next_variable();
+                        });
+                        local_map.insert(key, new_ident.clone());
+                        new_ident
+                    };
+                    quote! {
+                        {
+                            #[allow(unused_imports)] use ::tribles::query::TriblePattern;
+                            let v_var = { #af_ident.as_variable(#stored_ident) };
+                            constraints.push(Box::new(#set_ident.pattern(#e_ident, #a_var_ident, v_var)));
+                        }
+                    }
+                }
                 Value::Expr(ref expr) => {
                     quote! {
                         {
@@ -538,6 +591,7 @@ fn pattern_impl(input: TokenStream) -> syn::Result<TokenStream> {
             let mut constraints: ::std::vec::Vec<Box<dyn ::tribles::query::Constraint>> = ::std::vec::Vec::new();
             let #ctx_ident = __local_find_context!();
             let #set_ident = #set;
+            #local_tokens
             #attr_tokens
             #entity_tokens
             ::tribles::query::intersectionconstraint::IntersectionConstraint::new(constraints)
@@ -581,6 +635,12 @@ fn entity_impl(input: TokenStream) -> syn::Result<TokenStream> {
                     "variable bindings (?ident) are not allowed in entity!; use a literal expression here",
                 ));
             }
+            Value::LocalVar(ident) => {
+                return Err(syn::Error::new_spanned(
+                    ident,
+                    "local variable bindings (_?ident) are not allowed in entity!; use a literal expression here",
+                ));
+            }
         }
     } else {
         quote! {
@@ -598,6 +658,12 @@ fn entity_impl(input: TokenStream) -> syn::Result<TokenStream> {
                 return Err(syn::Error::new_spanned(
                     id,
                     "variable bindings (?ident) are not allowed in entity!; use a literal expression here",
+                ));
+            }
+            Value::LocalVar(id) => {
+                return Err(syn::Error::new_spanned(
+                    id,
+                    "local variable bindings (_?ident) are not allowed in entity!; use a literal expression here",
                 ));
             }
         };
@@ -697,6 +763,10 @@ fn pattern_changes_impl(input: TokenStream) -> syn::Result<TokenStream> {
     let mut value_decl_tokens = TokenStream2::new();
     let mut value_const_tokens = TokenStream2::new();
 
+    let mut local_decl_tokens = TokenStream2::new();
+    let mut local_map: HashMap<String, Ident> = HashMap::new();
+    let mut local_idx = 0usize;
+
     struct TripleInfo {
         e_ident: Ident,
         a_ident: Ident,
@@ -715,6 +785,22 @@ fn pattern_changes_impl(input: TokenStream) -> syn::Result<TokenStream> {
             Some(ref id_val) => match id_val {
                 Value::Var(ref ident) => {
                     entity_decl_tokens.extend(quote! { let #e_ident = #ident; });
+                }
+                Value::LocalVar(ref ident) => {
+                    let key = format!("_?{}", ident);
+                    let local_ident = if let Some(existing) = local_map.get(&key) {
+                        existing.clone()
+                    } else {
+                        let new_ident =
+                            format_ident!("__local{}", local_idx, span = Span::mixed_site());
+                        local_idx += 1;
+                        local_decl_tokens.extend(quote! {
+                            let #new_ident = #ctx_ident.next_variable();
+                        });
+                        local_map.insert(key, new_ident.clone());
+                        new_ident
+                    };
+                    entity_decl_tokens.extend(quote! { let #e_ident = #local_ident; });
                 }
                 Value::Expr(ref id_expr) => {
                     entity_const_tokens.extend(quote! {
@@ -777,6 +863,24 @@ fn pattern_changes_impl(input: TokenStream) -> syn::Result<TokenStream> {
                         let #v_ident = #af_ident.as_variable(#var_ident);
                     });
                 }
+                Value::LocalVar(ref ident) => {
+                    let key = format!("_?{}", ident);
+                    let local_ident = if let Some(existing) = local_map.get(&key) {
+                        existing.clone()
+                    } else {
+                        let new_ident =
+                            format_ident!("__local{}", local_idx, span = Span::mixed_site());
+                        local_idx += 1;
+                        local_decl_tokens.extend(quote! {
+                            let #new_ident = #ctx_ident.next_variable();
+                        });
+                        local_map.insert(key, new_ident.clone());
+                        new_ident
+                    };
+                    value_decl_tokens.extend(quote! {
+                        let #v_ident = #af_ident.as_variable(#local_ident);
+                    });
+                }
             }
 
             triples.push(TripleInfo {
@@ -835,6 +939,7 @@ fn pattern_changes_impl(input: TokenStream) -> syn::Result<TokenStream> {
             let #delta_ident = #changes;
             #ns_use
             #attr_decl_tokens
+            #local_decl_tokens
             #entity_decl_tokens
             #value_decl_tokens
             let mut constraints: ::std::vec::Vec<Box<dyn ::tribles::query::Constraint>> = ::std::vec::Vec::new();


### PR DESCRIPTION
## Summary
- add `_?name` parsing and context reuse for `pattern!` and `pattern_changes!`
- document scoped pattern locals and extend the changelog
- cover the new syntax with runtime and trybuild tests

## Testing
- cargo fmt
- cargo test
- ./scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d9678271808322aadbad4aa76f8659