### PR TITLE
UnionConstraint: reject empty constraint vectors at construction

### DIFF
--- a/triblespace-core/src/query/unionconstraint.rs
+++ b/triblespace-core/src/query/unionconstraint.rs
@@ -31,8 +31,15 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if the variants do not all declare the same variable set.
+    /// Panics if `constraints` is empty (a zero-arm union has no
+    /// well-defined variable set), or if the variants do not all
+    /// declare the same variable set.
     pub fn new(constraints: Vec<C>) -> Self {
+        assert!(
+            !constraints.is_empty(),
+            "UnionConstraint requires at least one variant; \
+             use a different constraint type for the empty case"
+        );
         assert!(constraints
             .iter()
             .map(|c| c.variables())
@@ -134,3 +141,17 @@ macro_rules! or {
 
 /// Re-export of the [`or!`] macro.
 pub use or;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::constantconstraint::ConstantConstraint;
+
+    #[test]
+    #[should_panic(expected = "UnionConstraint requires at least one variant")]
+    fn empty_union_panics_at_construction() {
+        // Without this assert, `variables()` would later panic on
+        // `self.constraints[0]` with an unhelpful index-out-of-bounds.
+        let _: UnionConstraint<ConstantConstraint> = UnionConstraint::new(vec![]);
+    }
+}


### PR DESCRIPTION
## Summary
- `UnionConstraint::new(vec![])` previously accepted an empty Vec, then panicked later from `variables()` with "index out of bounds: the len is 0 but the index is 0" because `variables()` returned `self.constraints[0]`. Public-API hole: a constructible `UnionConstraint` that panics on its first method call.
- Reachability is direct-API only — both `or!` and `pattern_changes!` require ≥1 arm at the macro layer. But the constructor is exposed, and the failure mode (deferred panic with an opaque message) was bad enough to surface explicitly with a clear `assert!`.
- Adds a `should_panic` test for the empty-input case.

## Provenance
Found via an adversarial codex review of the same-variables UnionConstraint design, prompted by a related session in liora exploring (and ultimately rejecting) a relaxation of the same-variables invariant for heterogeneous `or!`. Both reviews live in the liora wiki:
- relaxation review (rejected, three silent-wrong-result repros): wiki `0971847f…`
- same-variables review (this PR's source): wiki `f74758f4…`

## Test plan
- [x] `cargo test -p triblespace-core --release --lib` passes (256 passed, was 255 — +1 for the new test).
- [x] New test `query::unionconstraint::tests::empty_union_panics_at_construction` passes (#[should_panic] verifies the new assert fires with the expected message).
- [x] No existing test changes; the empty-vec path was unreachable in any test previously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)